### PR TITLE
Adição do pacote Flask-CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.vscode
-/__pycache__
+*__pycache__
+/venv
+/env

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ from pprint import pprint
 
 from flask import Flask, request, url_for, jsonify
 from flask_pymongo import PyMongo
+from flask_cors import CORS
 from pymongo.collection import Collection, ReturnDocument
 from pymongo.errors import DuplicateKeyError
 
@@ -13,8 +14,8 @@ from models.objectid import PydanticObjectId
 
 from config import Config
 
-
 app = Flask(__name__)
+CORS(app)
 app.config.from_object(Config)
 
 


### PR DESCRIPTION
Para solucionar o [problema](https://github.com/lead-ifal/pc2i-platform/issues/2#issue-993279219) de bloqueio de requisições pela política de CORS, foi adicionado o pacote Flask-CORS.

Além da adição do pacote, houve uma atualização no arquivo `.gitignore`, adicionando as pastas do ambiente virtual do Flask (`/venv` e `/env`) e todos os arquivos de cache do python (`__pycache__`).