### PR TITLE
Refatoramento da inserção e deleção de dados

### DIFF
--- a/app/controllers/culture_controller.py
+++ b/app/controllers/culture_controller.py
@@ -60,6 +60,11 @@ class CultureController:
 
                     cultures.insert_one(culture_data)
 
+                    irrigation_zones.find_one_and_update(
+                        {"_id": culture_data["irrigation_zone_id"]},
+                        {"$push": {"cultures": culture_data["_id"]}},
+                    )
+
                     return GlobalController.generate_response(
                         HTTP_CREATED_CODE, SUCCESS_MESSAGE, culture_data
                     )
@@ -75,7 +80,12 @@ class CultureController:
     @has_token
     def delete(culture_id):
         try:
-            cultures.find_one_and_delete({"_id": ObjectId(culture_id)})
+            culture = cultures.find_one_and_delete({"_id": ObjectId(culture_id)})
+
+            irrigation_zones.find_one_and_update(
+                {"_id": culture["irrigation_zone_id"]},
+                {"$pull": {"cultures": culture["_id"]}},
+            )
             return GlobalController.generate_response(
                 HTTP_SUCCESS_CODE, SUCCESS_MESSAGE, culture_id
             )

--- a/app/controllers/schedule_controller.py
+++ b/app/controllers/schedule_controller.py
@@ -21,6 +21,7 @@ from app.constants.response_messages import (
 from app.constants.required_params import required_params
 
 scheduled_irrigations: Collection = database.db.scheduled_irrigations
+irrigation_zones: Collection = database.db.irrigation_zones
 
 
 class ScheduleController:
@@ -53,7 +54,13 @@ class ScheduleController:
     @has_token
     def delete_schedule(schedule_id):
         try:
-            scheduled_irrigations.find_one_and_delete({"_id": ObjectId(schedule_id)})
+            schedule = scheduled_irrigations.find_one_and_delete(
+                {"_id": ObjectId(schedule_id)}
+            )
+            irrigation_zones.find_one_and_update(
+                {"_id": schedule["irrigation_zone_id"]},
+                {"$pull": {"schedules": schedule["_id"]}},
+            )
             return GlobalController.generate_response(
                 HTTP_SUCCESS_CODE, SUCCESS_MESSAGE, schedule_id
             )
@@ -75,6 +82,10 @@ class ScheduleController:
                 scheduling = ScheduleIrrigation(**body)
                 schedule_irrigation_data = scheduling.dict(exclude_none=True)
                 scheduled_irrigations.insert_one(schedule_irrigation_data)
+                irrigation_zones.find_one_and_update(
+                    {"_id": schedule_irrigation_data["irrigation_zone_id"]},
+                    {"$push": {"schedules": schedule_irrigation_data["_id"]}},
+                )
 
                 return GlobalController.generate_response(
                     HTTP_CREATED_CODE, SUCCESS_MESSAGE, schedule_irrigation_data

--- a/app/controllers/zone_controller.py
+++ b/app/controllers/zone_controller.py
@@ -39,6 +39,8 @@ class ZoneController:
         includes_params = GlobalController.includes_all_required_params(params, body)
         try:
             if includes_params:
+                body["cultures"] = []
+                body["schedules"] = []
                 body["user_id"] = ObjectId(body["user_id"])
                 irrigation_zone = IrrigationZone(**body)
                 irrigation_zone_data = irrigation_zone.dict(exclude_none=True)

--- a/app/models/irrigation_zone.py
+++ b/app/models/irrigation_zone.py
@@ -7,6 +7,8 @@ from app.models.objectid import PydanticObjectId
 class IrrigationZone(BaseModel):
     id: Optional[PydanticObjectId] = Field(alias="_id")
     user_id: ObjectId
+    cultures: list
+    schedules: list
     name: str
     description: str
     size: float


### PR DESCRIPTION
essa pr implementa o refatoramento da inserção e deleção de dados de culture e schedule para referenciar na irrigation_zone específica os ObjectIds das entidades que estão sendo inseridas atendendo a issue #126 

teste:
cultura adicionada:
![image](https://github.com/lead-ifal/pc2i-platform/assets/87715417/1e9b53f3-dacc-451d-a95b-4409089e554d)
o id da cultura é adicionado no campo cultures da irrigation-zone:
![image](https://github.com/lead-ifal/pc2i-platform/assets/87715417/253de395-64f8-4422-8394-5bf56a4096e7)
cultura deletada:
![image](https://github.com/lead-ifal/pc2i-platform/assets/87715417/82ac3c10-b5a1-4ad9-bfb6-08f9edbbf09c)

o id da cultura é removido:
![image](https://github.com/lead-ifal/pc2i-platform/assets/87715417/7fe51b35-b815-4323-a5f0-e51257e91584)


